### PR TITLE
Add new config MatchReset

### DIFF
--- a/WarcraftPlugin/Core/Database.cs
+++ b/WarcraftPlugin/Core/Database.cs
@@ -179,6 +179,15 @@ namespace WarcraftPlugin.Core
                     steamid = player.SteamID
                 });
         }
+
+        internal void ResetClients()
+        {
+            _connection.Execute(@"
+                DELETE FROM `players` WHERE 1;");
+
+            _connection.Execute(@"
+                DELETE FROM `raceinformation` WHERE 1;");
+        }
     }
 
     internal class DatabasePlayer

--- a/WarcraftPlugin/Core/Database.cs
+++ b/WarcraftPlugin/Core/Database.cs
@@ -186,7 +186,7 @@ namespace WarcraftPlugin.Core
                 DELETE FROM `players`;");
 
             _connection.Execute(@"
-                DELETE FROM `raceinformation` WHERE 1;");
+                DELETE FROM `raceinformation`;");
         }
     }
 

--- a/WarcraftPlugin/Core/Database.cs
+++ b/WarcraftPlugin/Core/Database.cs
@@ -183,7 +183,7 @@ namespace WarcraftPlugin.Core
         internal void ResetClients()
         {
             _connection.Execute(@"
-                DELETE FROM `players` WHERE 1;");
+                DELETE FROM `players`;");
 
             _connection.Execute(@"
                 DELETE FROM `raceinformation` WHERE 1;");


### PR DESCRIPTION
Added a new `MatchReset` config, to resets the database on map start and map end, to provide a fairer experience for new players joining the server.